### PR TITLE
Allow setting .on('done') after done emits

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,18 @@ class BundleWalker extends EE {
     this.bundle = null
   }
 
+  addListener (ev, fn) {
+    return this.on(ev, fn)
+  }
+
+  on (ev, fn) {
+    const ret = super.on(ev, fn)
+    if (ev === 'done' && this.didDone) {
+      this.emit('done', this.result)
+    }
+    return ret
+  }
+
   done () {
     if (!this.didDone) {
       this.didDone = true
@@ -57,7 +69,7 @@ class BundleWalker extends EE {
   }
 
   start () {
-    const pj = this.path + '/package.json'
+    const pj = path.resolve(this.path, 'package.json')
     if (this.packageJsonCache.has(pj))
       this.onPackage(this.packageJsonCache.get(pj))
     else


### PR DESCRIPTION
This takes care of a zalgo case, where doing something like this causes
problems, if the caches are full and there are no bundled deps to
investigate:

    bw = new BundleWalker({packageJsonCache}).start()
    bw.on('done', ...)

Root cause of test failures reported in
<https://github.com/npm/npm-packlist/pull/21>