### PR TITLE
docs: fix incorrect example of sync usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bundled({ path: '/path/to/pkg/defaults/to/cwd'}).then(list => {
 })
 
 // sync version, throws if there's an error
-const list = bundled({ path: '/path/to/pkg/defaults/to/cwd'})
+const list = bundled.sync({ path: '/path/to/pkg/defaults/to/cwd'})
 ```
 
 That's basically all you need to know.  If you care to dig into it,


### PR DESCRIPTION
Fixes a typo in the example usage documentation on how to call `npm-bundled` synchronously.

Encountered when I was trying to debug whether `bundledDependencies` worked when using NPM workspaces.
