### PR TITLE
fix!: align to npm 11 node engine range

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "@npmcli/eslint-config": "^5.0.0",
-    "@npmcli/template-oss": "4.27.1",
+    "@npmcli/template-oss": "4.25.0",
     "mutate-fs": "^2.1.1",
     "tap": "^16.3.0"
   },
@@ -33,11 +33,11 @@
     "npm-normalize-package-bin": "^4.0.0"
   },
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.27.1",
+    "version": "4.25.0",
     "publish": true
   },
   "tap": {


### PR DESCRIPTION
This PR updates the Node.js engine requirement to align with npm 11.

## Changes
- Updated `engines.node` in package.json to `^20.17.0 || >=22.9.0`

## Breaking Change
This is a breaking change as it drops support for Node.js versions outside the specified range.

**New requirement:** Node.js `^20.17.0 || >=22.9.0`